### PR TITLE
Introduce Continuous deployment to Appaloosa store

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: iOS Build
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+# eXo iOS application continuous deployment to Appaloosa.
+
+# Required Github secrets:
+
+# - SSH_KEY: Private SSH Key to allow accessing to a private Github repository.
+# - KNOWN_HOSTS: Known hosts containing Github servers fingerprints. Can be taken from existing one or Generate a one https://github.community/t/please-provide-ssh-known-hosts-for-gh-services-in-actions/16164/3. 
+# - MATCH_PASSWORD: Certificate's password
+# - KEYCHAIN_PASSWORD: Keychain Password (Generate a random password)
+# - API_TOKEN_APPALOOSA: Appaloosa Store api token
+# - STORE_ID_APPALOOSA: Appaloosa Store id
+
+name: eXo iOS Appaloosa CI/CD
+
+on:
+  push:
+    branches: [develop]
+jobs:
+  deploy: 
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Use SSH Key to gather certificate from a private Github repository. Use a dedicated on is recommended.
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      # Setup Ruby 2.6 (2.7 not yet compatible with bundler)  
+      - name: Setup ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      # Install Bundler and dependencies gems    
+      - name: Install bundler and dependencies        
+        run: gem install bundler && bundle install 
+      # Needed to install these packages for fastlane to generate badges  
+      - name: Install Homebrew badge packages
+        run: brew install librsvg imagemagick graphicsmagick
+      # Ensure installing latest version of fastlane  
+      - name: Upgrade fastlane
+        run: bundle update fastlane 
+      # Gather certificates from Github repository  
+      - name: Synchonize Certificates
+        uses: maierj/fastlane-action@v2.0.1
+        with:
+          lane: "ci_sync_certificates"
+        env:
+          BUNDLE_ID: com.exoplatform.mob.eXoPlatformiPHone
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}  
+          MATCH_KEYCHAIN_PASSWORD : ${{ secrets.KEYCHAIN_PASSWORD }}
+          MATCH_KEYCHAIN_NAME : ${{ secrets.KEYCHAIN_NAME }}
+      # Deploy eXo iOS bundle to appalossa store
+      - name: "Deploy eXo Beta to appaloosa"
+        uses: maierj/fastlane-action@v2.0.1
+        with:
+          lane: "build_beta_ppr"
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}  
+          MATCH_KEYCHAIN_PASSWORD : ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPALOOSA_EXO_API_TOKEN: ${{ secrets.API_TOKEN_APPALOOSA }}
+          APPALOOSA_EXO_STORE_ID: ${{ secrets.STORE_ID_APPALOOSA }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -230,7 +230,7 @@ platform :ios do
 
     ENV["EXO_APP_BASE_URL"] = "https://community.exoplatform.com"
     ENV["EXO_APP_ID"] = "com.exoplatform.mob.eXoPlatformiPHone"
-    ENV["EXO_APP_ENVIRONMENT"]="5.1-RC14"
+    ENV["EXO_APP_ENVIRONMENT"]="6.0-RC01"
     ENV["EXO_APP_IDENTIFIERS"]="#{ENV["EXO_APP_ID"]},#{ENV["EXO_APP_ID"]}.share-extension"
 
     add_badge(shield: "#{ENV["EXO_APP_ENVIRONMENT"]}-blue", dark: true)
@@ -267,6 +267,39 @@ platform :ios do
     )
     frame_screenshots(white: true)
     # upload_to_app_store
+  end
+
+  # Only for Github actions
+  desc "Sync CI Certificates"
+  lane :ci_sync_certificates do
+    create_keychain(
+      name: ENV["MATCH_KEYCHAIN_NAME"],
+      password: ENV["MATCH_KEYCHAIN_PASSWORD"],
+      default_keychain: true,
+      unlock: true,
+      timeout: 3600,
+      lock_when_sleeps: true,
+    )
+    bundleID = ENV["BUNDLE_ID"]
+    UI.header("Certicates will be generated following parameters")
+    UI.message("bundleID: #{bundleID}")
+    UI.success "Starting build"
+    ENV["EXO_APP_IDENTIFIERS"] = "#{bundleID},#{bundleID}.share-extension"
+    appIdentifiers = ENV["EXO_APP_IDENTIFIERS"].split(",")
+    match(
+      app_identifier: appIdentifiers,
+      type: "development",
+      readonly: true,
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"],
+    )
+    match(
+      app_identifier: appIdentifiers,
+      type: "adhoc",
+      readonly: true,
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"],
+    )
   end
 
 end


### PR DESCRIPTION
This PR adds the continuous deployment of eXo iOS to Appaloosa Store using Fastlane CLI. It also disables the autobuild of a merged commit to the main branch.

Required Github secrets:
 - SSH_KEY: Private SSH Key to allow accessing to a private Github repository.
 - KNOWN_HOSTS: Known hosts containing Github servers fingerprints. Can be taken from existing one or Generate a one https://github.community/t/please-provide-ssh-known-hosts-for-gh-services-in-actions/16164/3.
 - MATCH_PASSWORD: Certificate's password
 - KEYCHAIN_PASSWORD: Keychain Password (Generate a random password)
 - API_TOKEN_APPALOOSA: Appaloosa Store api token
 - STORE_ID_APPALOOSA: Appaloosa Store id