### PR TITLE
Update config to release snapshot versions with DEV version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           MATCH_KEYCHAIN_NAME: ${{ secrets.KEYCHAIN_NAME }}
       - name: Generate new version
         env:
-          TAG_PREFIX: "6.2-M"
+          TAG_PREFIX: "6.2-DEV"
         run: |
           git config --global user.email "exo-swf@exoplatform.com"
           git config --global user.name "eXo Software Factory"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -309,10 +309,10 @@ platform :ios do
     ENV["EXO_APP_EXPORT_TYPE_PROVISIONING"] = "AdHoc"
     ENV["EXO_APP_CONFIGURATION"] = "Release"
 
-    ENV["EXO_APP_BASE_URL"] = "https://community.exoplatform.com"
+    ENV["EXO_APP_BASE_URL"] = "https://maint-ft1.exoplatform.org"
     ENV["EXO_APP_ID"] = "org.exoplatform.exo-snapshot"
     if ! ENV["EXO_APP_ENVIRONMENT"]
-      ENV["EXO_APP_ENVIRONMENT"]="6.2-M01"
+      ENV["EXO_APP_ENVIRONMENT"]="6.2-DEV01"
     end
     ENV["EXO_APP_IDENTIFIERS"]="#{ENV["EXO_APP_ID"]},#{ENV["EXO_APP_ID"]}.share-extension"
 


### PR DESCRIPTION
This PR will change default config to :
 - replace snapshot versions prefix to DEV instead of M
 - Set the default configured eXo server to Maintenance server