### PR TITLE
49278 : make iOS 15 compatible with eXo mobile app

### DIFF
--- a/eXo/Sources/Controllers/OnboardingVC/OnboardingViewController.xib
+++ b/eXo/Sources/Controllers/OnboardingVC/OnboardingViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -184,10 +184,10 @@
                                     </constraints>
                                 </stackView>
                                 <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="Aje-hZ-J6V">
-                                    <rect key="frame" x="146" y="8" width="122" height="28"/>
+                                    <rect key="frame" x="118" y="8" width="178" height="28"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="28" id="gFU-FA-aZ8"/>
-                                        <constraint firstAttribute="width" constant="122" id="gLZ-Zr-iSQ"/>
+                                        <constraint firstAttribute="width" constant="178" id="gLZ-Zr-iSQ"/>
                                     </constraints>
                                     <color key="pageIndicatorTintColor" red="0.3411764706" green="0.55294117649999996" blue="0.78823529410000004" alpha="0.39866856166294645" colorSpace="custom" customColorSpace="sRGB"/>
                                     <color key="currentPageIndicatorTintColor" red="0.3411764706" green="0.55294117649999996" blue="0.78823529410000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Given i am a mobile user

When i have an iOS mobile with version 15 

Then i have to be able to use the application 

And we should not have an alert message that inform me about the incompatibility of this new iOS version.