### PR TITLE
49531 : Wrong pop up displayed when internet connection lost

### DIFF
--- a/eXo/Sources/Controllers/AddDomainVC/AddDomainViewController.swift
+++ b/eXo/Sources/Controllers/AddDomainVC/AddDomainViewController.swift
@@ -114,23 +114,24 @@ class AddDomainViewController: UIViewController,UITextFieldDelegate {
         // dismiss the keyboard
         view.endEditing(true)
         // check Internet connection
-        checkConnectivity()
         // verification of URL, http is the default protocol
         if let company = companyTextField.text, let sufixUrl = suffixUrlTextField.text {
             print(company,sufixUrl)
-            Tool.verificationServerURL(company+sufixUrl, delegate: self, handleSuccess: { (serverURL) -> Void in
-                self.selectedServer = Server (serverURL: serverURL)
-                OperationQueue.main.addOperation({ () -> Void in
-                    ServerManager.sharedInstance.addEditServer(self.selectedServer!)
-                    self.selectedServer?.lastConnection = Date().timeIntervalSince1970
-                   // UserDefaults.standard.setValue(self.selectedServer?.serverURL, forKey: "serverURL")
-                    self.dismiss(animated: true) {
-                        if let serverURL = self.selectedServer?.serverURL {
-                            self.postNotificationWith(key: .addDomainKey, info: ["serverURL" : serverURL])
+            if isInternetConnected(inWeb: false) {
+                Tool.verificationServerURL(company+sufixUrl, delegate: self, handleSuccess: { (serverURL) -> Void in
+                    self.selectedServer = Server (serverURL: serverURL)
+                    OperationQueue.main.addOperation({ () -> Void in
+                        ServerManager.sharedInstance.addEditServer(self.selectedServer!)
+                        self.selectedServer?.lastConnection = Date().timeIntervalSince1970
+                       // UserDefaults.standard.setValue(self.selectedServer?.serverURL, forKey: "serverURL")
+                        self.dismiss(animated: true) {
+                            if let serverURL = self.selectedServer?.serverURL {
+                                self.postNotificationWith(key: .addDomainKey, info: ["serverURL" : serverURL])
+                            }
                         }
-                    }
+                    })
                 })
-            })
+            }
         }
     }
 }

--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -173,11 +173,8 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
     }
     
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        if isInternetConnected(inWeb:true) {
-            loadingIndicator.stopAnimating()
-        }else{
-            loadingIndicator.stopAnimating()
-        }
+        checkConnectivity()
+        loadingIndicator.stopAnimating()
     }
     
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {

--- a/eXo/Sources/Controllers/OnboardingVC/OnboardingViewController.swift
+++ b/eXo/Sources/Controllers/OnboardingVC/OnboardingViewController.swift
@@ -90,21 +90,21 @@ class OnboardingViewController: UIViewController {
     func rootToHome(notification:Notification){
         guard let rootURL = notification.userInfo?["rootURL"] as? String else { return }
         // check Internet connection
-        checkConnectivity()
-        Tool.verificationServerURL(rootURL, delegate: self, handleSuccess: { (serverURL) -> Void in
-            self.qrCodeServer = Server(serverURL: serverURL)
-            OperationQueue.main.addOperation({ () -> Void in
-                ServerManager.sharedInstance.addEditServer(self.qrCodeServer!)
-                self.qrCodeServer?.lastConnection = Date().timeIntervalSince1970
-               // UserDefaults.standard.setValue(self.qrCodeServer?.serverURL, forKey: "serverURL")
-                let sb = UIStoryboard(name: "Main", bundle: nil)
-                let homepageVC = sb.instantiateViewController(withIdentifier: "HomePageViewController") as? HomePageViewController
-                if let homepageVC = homepageVC {
-                    homepageVC.serverURL = rootURL + "&source=qrcode"
-                    self.navigationController?.pushViewController(homepageVC, animated: true)
-                }
+        if isInternetConnected(inWeb:false) {
+            Tool.verificationServerURL(rootURL, delegate: self, handleSuccess: { (serverURL) -> Void in
+                self.qrCodeServer = Server(serverURL: serverURL)
+                OperationQueue.main.addOperation({ () -> Void in
+                    ServerManager.sharedInstance.addEditServer(self.qrCodeServer!)
+                    self.qrCodeServer?.lastConnection = Date().timeIntervalSince1970
+                    let sb = UIStoryboard(name: "Main", bundle: nil)
+                    let homepageVC = sb.instantiateViewController(withIdentifier: "HomePageViewController") as? HomePageViewController
+                    if let homepageVC = homepageVC {
+                        homepageVC.serverURL = rootURL + "&source=qrcode"
+                        self.navigationController?.pushViewController(homepageVC, animated: true)
+                    }
+                })
             })
-        })
+        }
     }
     
     @IBAction func addServerTapped(_ sender: Any) {

--- a/eXo/Sources/Utils/Extensions/UIViewController-Extension.swift
+++ b/eXo/Sources/Utils/Extensions/UIViewController-Extension.swift
@@ -69,6 +69,12 @@ extension UIViewController {
         }
     }
     
+    func checkConnectivity(){
+        if !Connectivity.shared.isInternetConnected() {
+            self.showAlertGeneralErrorNoNetwork(inWeb:true)
+        }
+    }
+    
     func showAlertGeneralErrorNoNetwork(inWeb:Bool){
         let titleAlert = "Internet connection lost".localized + "\n\n\n\n\n"
         let messageAlert = "\n\n" + "Please make sure you have internet connection".localized + "\n"

--- a/eXo/Sources/Utils/Extensions/UIViewController-Extension.swift
+++ b/eXo/Sources/Utils/Extensions/UIViewController-Extension.swift
@@ -60,42 +60,47 @@ extension UIViewController {
         return txtField.frame.size.width
     }
     
-    func checkConnectivity(){
-            if !Connectivity.shared.isInternetConnected() {
-                self.showAlertGeneralErrorNoNetwork()
-            }
+    func isInternetConnected(inWeb:Bool) -> Bool {
+        if Connectivity.shared.isInternetConnected() {
+            return true
+        }else{
+            self.showAlertGeneralErrorNoNetwork(inWeb:inWeb)
+            return false
         }
+    }
+    
+    func showAlertGeneralErrorNoNetwork(inWeb:Bool){
+        let titleAlert = "Internet connection lost".localized + "\n\n\n\n\n"
+        let messageAlert = "\n\n" + "Please make sure you have internet connection".localized + "\n"
         
-        func showAlertGeneralErrorNoNetwork(){
-            let titleAlert = "Internet connection lost".localized + "\n\n\n\n\n"
-            let messageAlert = "\n\n" + "Please make sure you have internet connection".localized + "\n"
-            
-            let attributedStringTitle = NSAttributedString(string: titleAlert, attributes: [
-                NSAttributedString.Key.font : UIFont.systemFont(ofSize: 15),
-                NSAttributedString.Key.foregroundColor : UIColor(rgb: 0x5A8EC7)
-            ])
-            let attributedStringMessage = NSAttributedString(string: messageAlert, attributes: [
-                NSAttributedString.Key.font : UIFont.systemFont(ofSize: 15),
-                NSAttributedString.Key.foregroundColor : UIColor(rgb: 0x5A8EC7)
-            ])
-            let alertController = UIAlertController(title: "", message: "", preferredStyle: .alert)
-            
-            alertController.setValue(attributedStringTitle, forKey: "attributedTitle")
-            alertController.setValue(attributedStringMessage, forKey: "attributedMessage")
-            alertController.view.tintColor = UIColor(rgb: 0x5A8EC7)
-            let imgViewTitle = UIImageView(frame: CGRect(x: 110, y: 80, width: 57, height: 50))
-            imgViewTitle.contentMode = .scaleAspectFill
-            if #available(iOS 13.0, *) {
-                imgViewTitle.image = UIImage(named: "wifi")?.withTintColor(UIColor(rgb: 0xa8b3c5))
-            } else {
-                imgViewTitle.image = UIImage(named: "wifi")
-            }
-            alertController.view.addSubview(imgViewTitle)
-            let okAction = UIAlertAction(title:"OK".localized, style: UIAlertAction.Style.default) { UIAlertAction in
+        let attributedStringTitle = NSAttributedString(string: titleAlert, attributes: [
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 15),
+            NSAttributedString.Key.foregroundColor : UIColor(rgb: 0x5A8EC7)
+        ])
+        let attributedStringMessage = NSAttributedString(string: messageAlert, attributes: [
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 15),
+            NSAttributedString.Key.foregroundColor : UIColor(rgb: 0x5A8EC7)
+        ])
+        let alertController = UIAlertController(title: "", message: "", preferredStyle: .alert)
+        
+        alertController.setValue(attributedStringTitle, forKey: "attributedTitle")
+        alertController.setValue(attributedStringMessage, forKey: "attributedMessage")
+        alertController.view.tintColor = UIColor(rgb: 0x5A8EC7)
+        let imgViewTitle = UIImageView(frame: CGRect(x: 110, y: 80, width: 57, height: 50))
+        imgViewTitle.contentMode = .scaleAspectFill
+        if #available(iOS 13.0, *) {
+            imgViewTitle.image = UIImage(named: "wifi")?.withTintColor(UIColor(rgb: 0xa8b3c5))
+        } else {
+            imgViewTitle.image = UIImage(named: "wifi")
+        }
+        alertController.view.addSubview(imgViewTitle)
+        let okAction = UIAlertAction(title:"OK".localized, style: UIAlertAction.Style.default) { UIAlertAction in
+            if inWeb {
                 let appDelegate = UIApplication.shared.delegate as! eXoAppDelegate
                 appDelegate.setRootOnboarding()
             }
-            alertController.addAction(okAction)
-            self.present(alertController, animated: true, completion: nil)
         }
+        alertController.addAction(okAction)
+        self.present(alertController, animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
Steps to reproduce :

Launch the exo application 

Click on "Enter server URL" button 

Disconnected the device from any type of internet and enter a correct eXo url adress to connect and click on "Done" button 

Expected behavior : 

the pop up " Internet connection lost " displayed conteins : 

Text : Please make sure you have internet connection 
Ok button 
Current behavior : 

pop up " Intranet URL error " displayed 

PS : the same behavior detected when scanning QR code when internet connction is lost

https://youtu.be/E--pUErEpl0