### PR TITLE
49356 : Handle internet connection in instance page

### DIFF
--- a/eXo/Sources/Controllers/ConnectToExoVC/ConnectToExoViewController.swift
+++ b/eXo/Sources/Controllers/ConnectToExoVC/ConnectToExoViewController.swift
@@ -144,7 +144,9 @@ extension ConnectToExoViewController:UITableViewDelegate,UITableViewDataSource{
             homepageVC.serverURL = self.selectedServer?.serverURL
             self.connectTableView.reloadData()
             navigationController?.navigationBar.isHidden = false
-            navigationController?.pushViewController(homepageVC, animated: true)
+            if isInternetConnected(inWeb: false) {
+                navigationController?.pushViewController(homepageVC, animated: true)
+            }
         }
     }
     


### PR DESCRIPTION
Prerequisite :

user have one saved instance on card 

Steps to reproduce : 

launch eXo app : card page displayed 
disconnect the device from any type of connection, and access the registered instance
Current behavior : 

a blank page is displayed

https://youtu.be/k5qCjf1WIvY

Expected behavior : 

the pop up " Internet connection lost " must be displayed  displayed