### PR TITLE
49856 : Blank page with Jitsi button && Roll back

### DIFF
--- a/eXo/Info.plist
+++ b/eXo/Info.plist
@@ -76,5 +76,15 @@
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+    <key>NSMicrophoneUsageDescription</key>
+       <string>Need microphone access for uploading videos</string>
+       <key>NSCameraUsageDescription</key>
+       <string>Need camera access for uploading images</string>
+       <key>NSLocationUsageDescription</key>
+       <string>Need location access for updating nearby friends</string>
+       <key>NSLocationWhenInUseUsageDescription</key>
+       <string>This app will use your location to show cool stuffs near you.</string>
+       <key>NSPhotoLibraryUsageDescription</key>
+       <string>Need photo library access for uploading images</string>
 </dict>
 </plist>

--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -305,24 +305,21 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
     // Called when a link opens a new window (target=_blank)
     // We simply reload the request in the existing webview
     // Cf http://stackoverflow.com/a/25853806
-    /*
-    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        /*
-        if (navigationAction.targetFrame == nil) {
-            webView.load(navigationAction.request)
-        }
-        return nil
-         */
-    }
-   */
 
-func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        popupWebView = WKWebView(frame: view.bounds, configuration: configuration)
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         popupWebView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        popupWebView = WKWebView(frame: .zero, configuration: configuration)
         popupWebView?.navigationDelegate = self
         popupWebView?.uiDelegate = self
         if let newWebview = popupWebView {
-            view.addSubview(newWebview)
+            self.webViewContainer.addSubview(newWebview)
+            newWebview.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                newWebview.leadingAnchor.constraint(equalTo: self.webViewContainer.leadingAnchor),
+                newWebview.trailingAnchor.constraint(equalTo: self.webViewContainer.trailingAnchor),
+                newWebview.topAnchor.constraint(equalTo: self.webViewContainer.topAnchor),
+                newWebview.bottomAnchor.constraint(equalTo: self.webViewContainer.bottomAnchor)
+            ])
         }
         return popupWebView ?? nil
     }


### PR DESCRIPTION
Given I am an iOS mobile user 

When i click on Call jitsi call 

Then i get a blank page.

Video: https://www.youtube.com/watch?v=8pW5Hr2qp_Q

Expected behavior: I need to have the call in the browser page.