### PR TITLE
49256 : received notification content still displayed even when user was disconnected

### DIFF
--- a/eXo/Sources/Models/PushTokenRestClient.swift
+++ b/eXo/Sources/Models/PushTokenRestClient.swift
@@ -22,7 +22,7 @@ class PushTokenRestClient {
     
     func registerToken(username: String, token: String, baseUrl: URL, completion: @escaping (Bool) -> Void) {
         let params = ["username": username, "token": token, "type": "ios"]
-        let registerTokenUrl = URL(string: baseUrl.absoluteString.serverDomainWithProtocolAndPort! + "/rest/private/v1/messaging/device")!
+        let registerTokenUrl = URL(string: baseUrl.absoluteString.serverDomainWithProtocolAndPort! + "/portal/rest/v1/messaging/device")!
         print("==== registerTokenUrl ========> \(registerTokenUrl)")
         print("==== Params ==================> \(params)")
         let request = createRequest(url: registerTokenUrl, method: "POST", data: try? JSONSerialization.data(withJSONObject: params, options: .prettyPrinted))
@@ -30,7 +30,7 @@ class PushTokenRestClient {
     }
     
     func unregisterToken(token: String, baseUrl: URL, completion: @escaping (Bool) -> Void) {
-        let unregisterTokenUrl = URL(string: baseUrl.absoluteString.serverDomainWithProtocolAndPort! + "/rest/private/v1/messaging/device/\(token)")!
+        let unregisterTokenUrl = URL(string: baseUrl.absoluteString.serverDomainWithProtocolAndPort! + "/portal/rest/v1/messaging/device/\(token)")!
         print("unregisterTokenUrl ========> \(unregisterTokenUrl)")
         let request = createRequest(url: unregisterTokenUrl, method: "DELETE", data: nil)
         doRequest(request) { result in


### PR DESCRIPTION
nv : 6.2 DEV 41

Steps to reproduce :

Connect to tribe using your private authentication details
Check your profile well displayed
Disconnect
Actual behavior : 

User well disconnected and instance well saved on card screen 
 Notifications still received with their content details 
Oppen the received notification , y're  invited to enter your authentication coordinate
https://youtu.be/fuFnvazDy88