### PR TITLE
51645 : [Gsuite]the connection parameters are always saved even after…

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -240,19 +240,14 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
         if let urlToSee = request.url?.absoluteString {
             print("=============== Navigation Url : \(urlToSee)")
         }
-        // Detect the logout action in to quit this screen.
-        if request.url?.absoluteString.range(of: "portal:action=Logout") != nil  {
-            PushTokenSynchronizer.shared.url = request.url?.absoluteString.serverDomainWithProtocolAndPort
-            PushTokenSynchronizer.shared.tryDestroyToken()
-            self.defaults.setValue(false, forKey: "wasConnectedBefore")
-            self.defaults.setValue("", forKey: "serverURL")
-            self.defaults.setValue(false, forKey: "isLoggedIn")
-            self.defaults.setValue(false, forKey: "isGoogleAuth")
-            let appDelegate = UIApplication.shared.delegate as! eXoAppDelegate
-            appDelegate.handleRootConnect()
-        }
-        let serverDomain = URL(string: self.serverURL!)?.host
         
+        // Detect the logout action in to quit this screen.
+        
+        if request.url?.absoluteString.range(of: "portal:action=Logout") != nil  {
+            logout(request: request)
+        }
+        
+        let serverDomain = URL(string: self.serverURL!)?.host
         if !UIApplication.shared.isNetworkActivityIndicatorVisible {
             UIApplication.shared.isNetworkActivityIndicatorVisible = true;
         }
@@ -436,6 +431,20 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
         } catch let error {
             print(error.localizedDescription)
         }
+    }
+    
+    // Logout : Destroy token device as well as clear user data .
+    
+    func logout(request:URLRequest) {
+        PushTokenSynchronizer.shared.url = request.url?.absoluteString.serverDomainWithProtocolAndPort
+        PushTokenSynchronizer.shared.tryDestroyToken()
+        self.defaults.setValue(false, forKey: "wasConnectedBefore")
+        self.defaults.setValue("", forKey: "serverURL")
+        self.defaults.setValue(false, forKey: "isLoggedIn")
+        self.defaults.setValue(false, forKey: "isGoogleAuth")
+        WKWebsiteDataStore.default().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: Date(timeIntervalSince1970: 0), completionHandler: {})
+        let appDelegate = UIApplication.shared.delegate as! eXoAppDelegate
+        appDelegate.handleRootConnect()
     }
     
 }


### PR DESCRIPTION
… disconnection & without check on remember me
Env : Beta 04

Steps to reproduce : 

Type the connection parameters without saving them
Disconnect and launch the site a second time and check 
Disconnect and delete the saved instance from card screen 
Expected behavior : 

for both cases ,user must be invited to re-enter his authentication details so that he can connect

Current behavior : 

the connection parameters are always saved even after disconnection and without check "remember me"

