### PR TITLE
53863 : Update on task relate to close button on chat

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -140,10 +140,6 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
     // MARK: Actions
     
     @IBAction func goBackAction(_ sender: AnyObject) {
-        if (webView?.canGoBack == true ) {
-            webView?.goBack()
-            doneButton.isHidden = true
-        }else{
             /*
              if the the request is loaded from different wkWebview we have close it instead of go back.
              */
@@ -151,7 +147,6 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
                 self.webViewDidClose(_popupWebView)
                 doneButton.isHidden = true
             }
-        }
     }
     
     // MARK: WKWebViewDelegate


### PR DESCRIPTION
When i open an image on chat i cannot close it as long it's opened on a different tab in the webview. 

Suggested behavior: 

We can preview the document with the document previewer we do have in the platform. 