### PR TITLE
54902 : Destroy token with Microsoft account

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -146,6 +146,9 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
             if let _popupWebView = popupWebView {
                 self.webViewDidClose(_popupWebView)
                 doneButton.isHidden = true
+            } else if (webView?.canGoBack == true ) {
+                webView?.goBack()
+                doneButton.isHidden = true
             }
     }
     

--- a/eXo/Sources/Models/PushTokenRestClient.swift
+++ b/eXo/Sources/Models/PushTokenRestClient.swift
@@ -17,7 +17,7 @@ class PushTokenRestClient {
     var rememberMeCookieValue: String?
     var isDuringSync = false
     var canDoRequest: Bool {
-        return !isDuringSync && sessionCookieValue != nil && rememberMeCookieValue != nil && sessionSsoCookieValue != nil
+        return !isDuringSync && sessionCookieValue != nil && sessionSsoCookieValue != nil
     }
     
     func registerToken(username: String, token: String, baseUrl: URL, completion: @escaping (Bool) -> Void) {
@@ -46,8 +46,17 @@ class PushTokenRestClient {
     private func createRequest(url: URL, method: String, data: Data?) -> URLRequest {
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: Config.timeout)
         var headers = ["Content-Type": "application/json"]
-        if let sessionCookieValue = sessionCookieValue, let rememberMeCookieValue = rememberMeCookieValue, let sessionSsoCookieValue = sessionSsoCookieValue {
-            headers["Cookie"] = "\(Cookies.session.rawValue)=\(sessionCookieValue); \(Cookies.rememberMe.rawValue)=\(rememberMeCookieValue); \(Cookies.sessionSso.rawValue)=\(sessionSsoCookieValue)"
+        // Setup RememberMe cookie just for community users
+        if let _url = url.host {
+            if _url.contains(Config.communityUrlDomain) {
+                if let sessionCookieValue = sessionCookieValue, let rememberMeCookieValue = rememberMeCookieValue, let sessionSsoCookieValue = sessionSsoCookieValue {
+                    headers["Cookie"] = "\(Cookies.session.rawValue)=\(sessionCookieValue); \(Cookies.rememberMe.rawValue)=\(rememberMeCookieValue); \(Cookies.sessionSso.rawValue)=\(sessionSsoCookieValue)"
+                }
+            }else{
+                if let sessionCookieValue = sessionCookieValue, let sessionSsoCookieValue = sessionSsoCookieValue {
+                    headers["Cookie"] = "\(Cookies.session.rawValue)=\(sessionCookieValue);  \(Cookies.sessionSso.rawValue)=\(sessionSsoCookieValue)"
+                }
+            }
         }
         request.allHTTPHeaderFields = headers
         request.httpMethod = method

--- a/eXo/Sources/defines.swift
+++ b/eXo/Sources/defines.swift
@@ -30,6 +30,7 @@ struct Config {
     // eXo Apple Store link
     static let eXoAppleStoreUrl:String = "https://apps.apple.com/us/app/exo/id410476273"
     static let communityURL:String =  "https://community.exoplatform.com"
+    static let communityUrlDomain:String =  "community.exoplatform"
     static let minimumPlatformVersionSupported:Float = 4.3
     static let maximumShortcutAllow:Int = 4
     static let timeout:TimeInterval = 60.0 // in seconds


### PR DESCRIPTION
We need to destroy the token device when we connect with a Microsoft account on iOS.