### PR TITLE
54902 : Destroy token with Microsoft account

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -140,13 +140,15 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
     // MARK: Actions
     
     @IBAction func goBackAction(_ sender: AnyObject) {
-            /*
-             if the the request is loaded from different wkWebview we have close it instead of go back.
-             */
-            if let _popupWebView = popupWebView {
-                self.webViewDidClose(_popupWebView)
-                doneButton.isHidden = true
-            }
+        /*
+         if the the request is loaded from different wkWebview we have close it instead of go back.
+         */
+        if let _popupWebView = popupWebView {
+            self.webViewDidClose(_popupWebView)
+        }else if (webView?.canGoBack == true ) {
+            webView?.goBack()
+        }
+        doneButton.isHidden = true
     }
     
     // MARK: WKWebViewDelegate

--- a/eXo/Sources/Models/PushTokenRestClient.swift
+++ b/eXo/Sources/Models/PushTokenRestClient.swift
@@ -17,7 +17,7 @@ class PushTokenRestClient {
     var rememberMeCookieValue: String?
     var isDuringSync = false
     var canDoRequest: Bool {
-        return !isDuringSync && sessionCookieValue != nil && rememberMeCookieValue != nil && sessionSsoCookieValue != nil
+        return !isDuringSync && sessionCookieValue != nil && sessionSsoCookieValue != nil
     }
     
     func registerToken(username: String, token: String, baseUrl: URL, completion: @escaping (Bool) -> Void) {
@@ -46,8 +46,8 @@ class PushTokenRestClient {
     private func createRequest(url: URL, method: String, data: Data?) -> URLRequest {
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: Config.timeout)
         var headers = ["Content-Type": "application/json"]
-        if let sessionCookieValue = sessionCookieValue, let rememberMeCookieValue = rememberMeCookieValue, let sessionSsoCookieValue = sessionSsoCookieValue {
-            headers["Cookie"] = "\(Cookies.session.rawValue)=\(sessionCookieValue); \(Cookies.rememberMe.rawValue)=\(rememberMeCookieValue); \(Cookies.sessionSso.rawValue)=\(sessionSsoCookieValue)"
+        if let sessionCookieValue = sessionCookieValue, let sessionSsoCookieValue = sessionSsoCookieValue {
+            headers["Cookie"] = "\(Cookies.session.rawValue)=\(sessionCookieValue);  \(Cookies.sessionSso.rawValue)=\(sessionSsoCookieValue)"
         }
         request.allHTTPHeaderFields = headers
         request.httpMethod = method
@@ -92,7 +92,7 @@ class PushTokenRestClient {
            var request = URLRequest(url: checkSessionURL, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: Config.timeout)
            var headers = ["Content-Type": "application/json"]
            if let sessionCookieValue = sessionCookieValue, let rememberMeCookieValue = rememberMeCookieValue, let sessionSsoCookieValue = sessionSsoCookieValue {
-               headers["Cookie"] = "\(Cookies.session.rawValue)=\(sessionCookieValue); \(Cookies.rememberMe.rawValue)=\(rememberMeCookieValue); \(Cookies.sessionSso.rawValue)=\(sessionSsoCookieValue)"
+               headers["Cookie"] = "\(Cookies.session.rawValue)=\(sessionCookieValue);  \(Cookies.sessionSso.rawValue)=\(sessionSsoCookieValue)"
            }
            request.allHTTPHeaderFields = headers
            request.httpMethod = "GET"


### PR DESCRIPTION
We need to destroy the token device when we connect with a Microsoft account on iOS.