### PR TITLE
55359 : Display alert message when downloading a document with os ver…

### DIFF
--- a/eXo/Resources/en.lproj/Localizable.strings
+++ b/eXo/Resources/en.lproj/Localizable.strings
@@ -124,3 +124,10 @@
 "Add your eXo" = "New eXo Connection";
 
 "Enter your eXo URL" = "Enter your eXo connection address";
+
+// Home Page
+
+"Download Unavailable" = "Download Unavailable";
+
+"You can't download the document, your os is less than iOS 15." = "You can't download the document, your os is less than iOS 15.";
+

--- a/eXo/Resources/fr.lproj/Localizable.strings
+++ b/eXo/Resources/fr.lproj/Localizable.strings
@@ -124,3 +124,9 @@
 "Add your eXo" = "Nouvelle connexion";
 
 "Enter your eXo URL" = "Entrer l'adresse de votre eXo";
+
+// Home Page
+
+"Download Unavailable" = "Téléchargement indisponible";
+
+"You can't download the document, your os is less than iOS 15." = "Vous ne pouvez pas télécharger le document, votre OS est inférieur à iOS 15.";

--- a/eXo/Sources/Controllers/AddDomainVC/CustomPopupVC/CustomPopupViewController.xib
+++ b/eXo/Sources/Controllers/AddDomainVC/CustomPopupVC/CustomPopupViewController.xib
@@ -60,7 +60,7 @@
                             <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Title Title Title Title Title Title Title Title Title Title Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DaW-4w-fuS">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Title Title Title Title Title Title Title Title Title Title Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="DaW-4w-fuS">
                             <rect key="frame" x="32" y="58.5" width="230" height="45"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="45" id="E7G-4i-rSO"/>

--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -202,6 +202,7 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
             if #available(iOS 15.0, *) {
                 decisionHandler(.download)
             }else{
+                showAlertMessage(title: "Download Unavailable".localized, msg: "You can't download the document, your os is less than iOS 15.".localized, action: .defaultAction)
                 decisionHandler(.cancel)
             }
             return


### PR DESCRIPTION
…sion less than 15

Given I am a mobile user in the platform

When i download a document from the activity stream attachment of an activity (using the url /portal/dw/downlaod)

And my iOS version is less than 15

Then i get an alert message : You can't download the document, your os is less than iOS 15.