### PR TITLE
55666 : Use native system when i download a document

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -475,6 +475,7 @@ class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, WKUIDe
         let appDelegate = UIApplication.shared.delegate as! eXoAppDelegate
         appDelegate.handleRootConnect()
     }
+    
 }
 
 extension HomePageViewController {

--- a/eXo/Sources/Utils/Extensions/UIViewController-Extension.swift
+++ b/eXo/Sources/Utils/Extensions/UIViewController-Extension.swift
@@ -118,4 +118,31 @@ extension UIViewController {
         alertController.addAction(okAction)
         self.present(alertController, animated: true, completion: nil)
     }
+    
+    // MARK: - Send notification while tracking the download status.
+    
+    func sendNotificationForDownload(_ filename:String,_ status: DownloadStatus) {
+        let content = UNMutableNotificationContent()
+        var notifTitle = ""
+        var notifBody = ""
+        switch status {
+        case .completed:
+            notifTitle = "Download completed"
+            notifBody = "\(filename) downloaded successfully"
+            break
+        case .started:
+            notifTitle = "Download started"
+            notifBody = "The download of \(filename) has been started"
+            break
+        case .failed:
+            notifTitle = "Download failed"
+            notifBody = "Failed to download the file \(filename)"
+            break
+        }
+        content.title = notifTitle
+        content.body = notifBody
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+        let request = UNNotificationRequest(identifier: "notification.id.01", content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
 }


### PR DESCRIPTION
Given I'm a user in the platform using the mobile app

When i donwload a document

Then the native system should be applied to download it and display the status of this download.