### PR TITLE
Task-60268: Mobile_Visioconference_Task, Join a call on mobile

### DIFF
--- a/eXo/Info.plist
+++ b/eXo/Info.plist
@@ -87,5 +87,9 @@
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+    <string>org.jitsi.meet</string>
+    </array>
 </dict>
 </plist>

--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -286,12 +286,19 @@ final class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, 
             // launch the call.
             print("launching the call...")
             // launch the call using the app.
-            if let jitsiUrl = request.url, (jitsiUrl.absoluteString.range(of: "org.jitsi.meet:") != nil) {
-                if UIApplication.shared.canOpenURL(jitsiUrl){
-                    UIApplication.shared.open(jitsiUrl)
-                } else {
-                    //Show alert message because the user doesn't have Jitsi App installed.
-                    showAlertMessage(title: "Jitsi Alert", msg: "Jitsi meet is not on your mobile, install it before.", action: .defaultAction)
+            if let jitsiUrl = request.url {
+                let arrUrl = jitsiUrl.absoluteString.components(separatedBy: "?jwt=")
+                let prefixCall = arrUrl.first!
+                let callUrl = prefixCall + "?jwt=" + valueForKeyInURL("jwt", jitsiUrl)!
+                if let jitsiAppUrl = URL(string:"org.jitsi.meet://" + callUrl.stringURLWithoutProtocol()) {
+                    if UIApplication.shared.canOpenURL(jitsiAppUrl) {
+                        UIApplication.shared.open(jitsiAppUrl)
+                        if let _popupWebView = popupWebView {
+                            self.webViewDidClose(_popupWebView)
+                        }else if (webView.canGoBack == true ) {
+                            webView.goBack()
+                        }
+                    }
                 }
             }
         }

--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -626,4 +626,22 @@ extension HomePageViewController:WKDownloadDelegate {
     
 }
 
-
+extension HomePageViewController {
+    func valueForKeyInURL(_ key: String?, _ url: URL?) -> String? {
+        var components: NSURLComponents? = nil
+        if let url = url {
+            components = NSURLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false)
+        }
+        var theField: NSURLQueryItem? = nil
+        for item in components?.queryItems ?? [] {
+            let item = item as NSURLQueryItem
+            if item.name == key {
+                theField = item
+                break
+            }
+        }
+        return theField?.value
+    }
+}


### PR DESCRIPTION
Current behavior:

When I try to join a call I have a jitsi page that proposes 3 options (join this meeting using the app, download the app, launch in web) to decide in which app the call should be opened.

Expected behavior: 

We should not have this page and the choice should be automatic according to our configuration: 

If I have on my phone the jitsi application already installed.

Then I'm redirected to the jitsi app and I have the loading page to join the appropriate call. 
When I close the call I'm on the jitsi app call history, I have to manually going back to eXo
If I do not have on my phone the jistsi application.

Then the call is launched on the browser. I stay on the eXo app, I don't remark that the call is launched in a browser as it's already implemented if I choose "launch in web". I have the loading page to join the call.
When I hang up the call, the call is closed and I'm going back to my previous opened page.