### PR TITLE
fix: failed registration of iOS devices - EXO-64019

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -208,6 +208,18 @@ final class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, 
         if let urlToSee = webView.url?.absoluteString {
             print("=============== didFinish Url : \(urlToSee)")
         }
+        
+        // Get username from JS variable
+        webView.evaluateJavaScript("eXo.env.portal.userName") { (result, error) in
+            if let userName = result as? String {
+                if !userName.isEmpty {
+                    print("eXo debug : userName is \(userName)")
+                    PushTokenSynchronizer.shared.username = userName
+                    PushTokenSynchronizer.shared.url = webView.url?.absoluteString.serverDomainWithProtocolAndPort
+                    PushTokenSynchronizer.shared.trySynchronizeToken()
+                }
+            }
+        }
     }
     
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
@@ -329,7 +341,7 @@ final class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, 
         // Home Page Address: portal/dw
         
         if let urlRequest = request.url {
-            if (urlRequest.path.contains("/portal/dw") || urlRequest.path.contains("/portal/g/")) && !(request.url?.absoluteString.range(of: "portal:action=Logout") != nil){
+            if (urlRequest.path.contains("/portal/dw") || urlRequest.path.contains("/portal/g/")) && (request.url?.absoluteString.range(of: "portal:action=Logout") == nil){
                 let path = urlRequest.path
                 let firstIndexPath = urlRequest.path.contains("/portal/dw") ? path.components(separatedBy: "/dw")[0] : path.components(separatedBy: "/g/")[0]
                 if firstIndexPath == "/portal"{

--- a/eXo/Sources/Models/Cookies/CookiesInterceptor.swift
+++ b/eXo/Sources/Models/Cookies/CookiesInterceptor.swift
@@ -14,7 +14,7 @@ protocol CookiesInterceptor {
 
 class CookiesInterceptorFactory {
     func create() -> CookiesInterceptor {
-        return CookiesInterceptorProxy(interceptors: [SessionCookieInterceptor(), RememberMeCookieInterceptor(), UsernameCookieInterceptor()])
+        return CookiesInterceptorProxy(interceptors: [SessionCookieInterceptor(), RememberMeCookieInterceptor() ])
     }
 }
 
@@ -47,15 +47,5 @@ fileprivate class RememberMeCookieInterceptor: CookiesInterceptor {
     func intercept(_ cookies: [HTTPCookie], url: URL) {
         guard let rememberMe = cookies.first(where: { $0.name == Cookies.rememberMe.rawValue })?.value else { return }
         PushTokenRestClient.shared.rememberMeCookieValue = rememberMe
-    }
-}
-
-fileprivate class UsernameCookieInterceptor: CookiesInterceptor {
-    func intercept(_ cookies: [HTTPCookie], url: URL) {
-        if let usernameCookie = cookies.first(where: { $0.name == Cookies.username.rawValue}) {
-            PushTokenSynchronizer.shared.username = usernameCookie.value
-            PushTokenSynchronizer.shared.url = url.absoluteString.serverDomainWithProtocolAndPort
-        }
-        PushTokenSynchronizer.shared.trySynchronizeToken()
     }
 }


### PR DESCRIPTION
Before this fix, the username of the logged-in user was retrieved from a cookie. This cookie was removed since eXo platform 6.5 , thus registering new iOS devices was failing because the username was not found. the fix retrieves the username from a global JS variable eXo.env.portal.userName and uses it to register the iOS device to receive push notifications.