### PR TITLE
fix: remove workaround to make user/space suggester work again - EXO-62784

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -70,9 +70,10 @@ final class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, 
             // register the bridge script that listens for the output
             webView?.configuration.userContentController.add(
                 LeakAvoider(delegate:self), name: "logHandler")
-            if #available(macOS 13.3, iOS 16.4, *) {
-                webView?.isInspectable = true
-            }
+            // Uncomment to inspect code when using iOS 16.4 or higher
+            //if #available(macOS 13.3, iOS 16.4, *) {
+                //webView?.isInspectable = true
+            //}
             self.configureDoneButton()
         }
     }

--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -56,7 +56,11 @@ final class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, 
             self.setupWebView(self.webViewContainer)
             webView?.navigationDelegate = self
             webView?.uiDelegate = self
-            webView?.configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+            if #available(iOS 14, *){
+                webView?.configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+            } else {
+                webView?.configuration.preferences.javaScriptEnabled = true
+            }
             webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
             webView?.setKeyboardRequiresUserInteraction(false)
             // inject JS to capture console.log output and send to iOS


### PR DESCRIPTION
A workaround was introduced to avoid a bug in Safari in https://github.com/exoplatform/exo-ios/commit/d400fff078502357b0780eea5ae83af1f05a4835
This WA is no more needed totally, the listener was causing issues with user/space suggester thus it is removed in this PR
the remaining parts of the WA were kept
An instruction was added to allow inspecting code from the browser when needed 