### PR TITLE
fix: remove workaround to make user/space suggester work again - EXO-62784

### DIFF
--- a/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
+++ b/eXo/Sources/Controllers/HomePage/HomePageViewController.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2003-2015 eXo Platform SAS.
+// Copyright (C) 2003-2023 eXo Platform SAS.
 //
 // This is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License as
@@ -56,21 +56,24 @@ final class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, 
             self.setupWebView(self.webViewContainer)
             webView?.navigationDelegate = self
             webView?.uiDelegate = self
-            webView?.configuration.preferences.javaScriptEnabled = true
+            if #available(iOS 14, *){
+                webView?.configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+            } else {
+                webView?.configuration.preferences.javaScriptEnabled = true
+            }
             webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
             webView?.setKeyboardRequiresUserInteraction(false)
             // inject JS to capture console.log output and send to iOS
             let captureLogSource = "function captureLog(msg) { window.webkit.messageHandlers.logHandler.postMessage(msg); } window.console.log = captureLog;"
-            let iOSListenerSource = "document.addEventListener('mouseout', function(){ window.webkit.messageHandlers.iosListener.postMessage('iOS Listener executed!'); })"
             let captureLogScript = WKUserScript(source: captureLogSource, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-            let iOSListenerScript = WKUserScript(source: iOSListenerSource, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
             webView?.configuration.userContentController.addUserScript(captureLogScript)
-            webView?.configuration.userContentController.addUserScript(iOSListenerScript)
             // register the bridge script that listens for the output
             webView?.configuration.userContentController.add(
                 LeakAvoider(delegate:self), name: "logHandler")
-            webView?.configuration.userContentController.add(
-                LeakAvoider(delegate:self), name: "iosListener")
+            // Uncomment to inspect code when using iOS 16.4 or higher
+            //if #available(macOS 13.3, iOS 16.4, *) {
+                //webView?.isInspectable = true
+            //}
             self.configureDoneButton()
         }
     }
@@ -440,10 +443,6 @@ final class HomePageViewController: eXoWebBaseController, WKNavigationDelegate, 
                     parseCallState(message:message.body as! String)
                 }
             }
-        }
-        if message.name == "iosListener" {
-            print("iosListener =====> : \(message.body)")
-            self.view.endEditing(true)
         }
     }
     


### PR DESCRIPTION
A workaround was introduced to avoid a bug in Safari in d400fff This WA is no more needed totally, the listener was causing issues with user/space suggester thus it is removed in this PR the remaining parts of the WA were kept
An instruction was added to allow inspecting code from the browser when needed